### PR TITLE
Chore: move program.auth.webCrypto to sessionStore.authStrategy

### DIFF
--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -3,7 +3,7 @@ import type FileSystem from 'webnative/fs/index'
 import { get as getStore } from 'svelte/store'
 
 import { asyncDebounce } from '$lib/utils'
-import { filesystemStore, programStore, sessionStore } from '../../stores'
+import { filesystemStore, sessionStore } from '../../stores'
 import { getBackupStatus } from '$lib/auth/backup'
 import { ACCOUNT_SETTINGS_DIR } from '$lib/account-settings'
 import { AREAS } from '$routes/gallery/stores'
@@ -11,15 +11,15 @@ import { GALLERY_DIRS } from '$routes/gallery/lib/gallery'
 
 
 export const isUsernameValid = async (username: string): Promise<boolean> => {
-  const program = getStore(programStore)
-  return program.auth[ webnative.strategyTypes.default ].isUsernameValid(username)
+  const session = getStore(sessionStore)
+  return session.authStrategy.isUsernameValid(username)
 }
 
 const _isUsernameAvailable = async (
   username: string
 ) => {
-  const program = getStore(programStore)
-  return program.auth[ webnative.strategyTypes.default ].isUsernameAvailable(username)
+  const session = getStore(sessionStore)
+  return session.authStrategy.isUsernameAvailable(username)
 }
 
 const debouncedIsUsernameAvailable = asyncDebounce(
@@ -34,8 +34,7 @@ export const isUsernameAvailable = async (
 }
 
 export const register = async (username: string): Promise<boolean> => {
-  const program = getStore(programStore)
-  const authStrategy = program.auth[ webnative.strategyTypes.default ]
+  const authStrategy = getStore(sessionStore).authStrategy
   const { success } = await authStrategy.register({ username })
 
   if (!success) return success
@@ -67,8 +66,7 @@ const initializeFilesystem = async (fs: FileSystem): Promise<void> => {
 }
 
 export const loadAccount = async (username: string): Promise<void> => {
-  const program = getStore(programStore)
-  const session = await program.auth[ webnative.strategyTypes.default ].session()
+  const session = await getStore(sessionStore).authStrategy.session()
 
   filesystemStore.set(session.fs)
 

--- a/src/lib/auth/linking.ts
+++ b/src/lib/auth/linking.ts
@@ -1,20 +1,20 @@
-import * as webnative from 'webnative'
+import type * as webnative from 'webnative'
 import { get as getStore } from 'svelte/store'
 
-import { programStore } from '$src/stores'
+import { sessionStore } from '$src/stores'
 
 
 export const createAccountLinkingConsumer = async (
   username: string
 ): Promise<webnative.AccountLinkingConsumer> => {
-  const program = getStore(programStore)
-  if (program) return program.auth[ webnative.strategyTypes.default ].accountConsumer(username)
+  const session = getStore(sessionStore)
+  if (session.authStrategy) return session.authStrategy.accountConsumer(username)
 
   // Wait for program to be initialised
   return new Promise((resolve) => {
-    programStore.subscribe(program => {
-      if (!program) return
-      const consumer = program.auth[ webnative.strategyTypes.default ].accountConsumer(username)
+    sessionStore.subscribe(updatedState => {
+      if (!updatedState.authStrategy) return
+      const consumer = updatedState.authStrategy.accountConsumer(username)
       resolve(consumer)
     })
   })
@@ -23,6 +23,6 @@ export const createAccountLinkingConsumer = async (
 export const createAccountLinkingProducer = async (
   username: string
 ): Promise<webnative.AccountLinkingProducer> => {
-  const program = getStore(programStore)
-  return program.auth[ webnative.strategyTypes.default ].accountProducer(username)
+  const session = getStore(sessionStore)
+  return session.authStrategy.accountProducer(username)
 }

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,19 +1,16 @@
 import * as webnative from 'webnative'
 
-import { filesystemStore, programStore, sessionStore } from '../stores'
+import { filesystemStore, sessionStore } from '../stores'
 import { getBackupStatus, type BackupStatus } from '$lib/auth/backup'
-
 
 export const initialize = async (): Promise<void> => {
   try {
     let backupStatus: BackupStatus = null
 
     const program: webnative.Program = await webnative.program({
-      id: { creator: "Fission", name: "WAT" },
+      id: { creator: 'Fission', name: 'WAT' },
       debug: false // TODO: Add a flag or script to turn debugging on/off
     })
-
-    programStore.set(program)
 
     if (program.session) {
       // Authed
@@ -22,6 +19,7 @@ export const initialize = async (): Promise<void> => {
       sessionStore.set({
         username: program.session.username,
         session: program.session,
+        authStrategy: program.auth.webCrypto,
         loading: false,
         backupCreated: backupStatus.created
       })
@@ -33,6 +31,7 @@ export const initialize = async (): Promise<void> => {
       sessionStore.set({
         username: '',
         session: null,
+        authStrategy: null,
         loading: false,
         backupCreated: null
       })

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,9 +1,11 @@
+import type * as webnative from 'webnative'
+
 import { appName } from '$lib/app-info'
-import type { Session as WebnativeSession } from 'webnative'
 
 export type Session = {
   username: string
-  session: WebnativeSession | null
+  session: webnative.Session | null
+  authStrategy: webnative.AuthenticationStrategies | null
   loading: boolean
   backupCreated: boolean
   error?: SessionError

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,5 +1,4 @@
 import { writable } from 'svelte/store'
-import type { Program } from 'webnative'
 import type { Writable } from 'svelte/store'
 import type FileSystem from 'webnative/fs/index'
 
@@ -14,6 +13,7 @@ export const themeStore: Writable<Theme> = writable(loadTheme())
 export const sessionStore: Writable<Session> = writable({
   username: null,
   session: null,
+  authStrategy: null,
   loading: true,
   backupCreated: null
 })
@@ -21,8 +21,6 @@ export const sessionStore: Writable<Session> = writable({
 export const filesystemStore: Writable<FileSystem | null> = writable(null)
 
 export const notificationStore: Writable<Notification[]> = writable([])
-
-export const programStore: Writable<Program | null> = writable(null)
 
 export const accountSettingsStore: Writable<AccountSettings> = writable({
   avatar: null,


### PR DESCRIPTION
# Description

Moving `program.auth[ webnative.strategyTypes.default ]`, which is equal to `program.auth.webCrypto`, into `sessionStore.authStrategy` and removing the `programStore`.

<b>Note: I tried importing various types from webnative to determine the correct type for [the authStrategy property](https://github.com/webnative-examples/webnative-app-template/pull/93/files#diff-21fc10c4f94655deceb24134026474bee0fde89cd94b7b8b1a288b08b30cd5d0R8), but I didn't have any luck. @icidasset I tried `AuthenticationStrategies`,  `Implementation<Crypto>` and `Implementation<Components>`, but none of them seemed to work 🤔  do you know what the correct type is?</b>

## Link to issue

https://github.com/webnative-examples/webnative-app-template/pull/89#discussion_r1023921224

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)
