### PR TITLE
Avivash/update old username format in init

### DIFF
--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -3,7 +3,7 @@ import * as webnative from 'webnative'
 import { dev } from '$app/environment'
 import { filesystemStore, sessionStore } from '../stores'
 import { getBackupStatus, type BackupStatus } from '$lib/auth/backup'
-import { USERNAME_STORAGE_KEY } from '$lib/auth/account'
+import { USERNAME_STORAGE_KEY, createDID } from '$lib/auth/account'
 import { webnativeNamespace } from '$lib/app-info'
 
 export const initialize = async (): Promise<void> => {
@@ -19,7 +19,15 @@ export const initialize = async (): Promise<void> => {
       // Authed
       backupStatus = await getBackupStatus(program.session.fs)
 
-      const fullUsername = await program.components.storage.getItem(USERNAME_STORAGE_KEY) as string
+      let fullUsername = await program.components.storage.getItem(USERNAME_STORAGE_KEY) as string
+
+      // If the user is migrating from a version of webnative < 0.35.0, their username won't be in storage yet
+      // and won't contain a did, so we will need to manually append a DID and add it storage here
+      if (!fullUsername) {
+        const did = await createDID(program.components.crypto)
+        fullUsername = `${program.session.username}#${did}`
+        await program.components.storage.setItem(USERNAME_STORAGE_KEY, fullUsername)
+      }
 
       sessionStore.set({
         username: {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -21,8 +21,8 @@ export const initialize = async (): Promise<void> => {
 
       let fullUsername = await program.components.storage.getItem(USERNAME_STORAGE_KEY) as string
 
-      // If the user is migrating from a version of webnative < 0.35.0, their username won't be in storage yet
-      // and won't contain a did, so we will need to manually append a DID and add it storage here
+      // If the user is migrating from a version webnative-app-template before https://github.com/webnative-examples/webnative-app-template/pull/97/files#diff-a180510e798b8f833ebfdbe691c5ec4a1095076980d3e2388de29c849b2b8361R44,
+      // their username won't contain a did, so we will need to manually append a DID and add it storage here
       if (!fullUsername) {
         const did = await createDID(program.components.crypto)
         fullUsername = `${program.session.username}#${did}`

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -27,6 +27,7 @@ export const initialize = async (): Promise<void> => {
         const did = await createDID(program.components.crypto)
         fullUsername = `${program.session.username}#${did}`
         await program.components.storage.setItem(USERNAME_STORAGE_KEY, fullUsername)
+        window.location.reload()
       }
 
       sessionStore.set({

--- a/src/routes/delegate-account/+page.svelte
+++ b/src/routes/delegate-account/+page.svelte
@@ -56,7 +56,8 @@
             $themeStore.selectedTheme === 'light' ? '#FAFAFA' : '#171717',
           padding: 0,
           width: 250,
-          height: 250
+          height: 250,
+          join: true
         }).svg()
 
         initAccountLinkingProducer(hashedUsername)


### PR DESCRIPTION
# Description

Adding a fix to adapt usernames from the old version(that didn't contain the `#<DID>`) to work with the new WAT. I think the `location.reload` may be optional, but I didn't see the gallery working correctly until after I did a page refresh 

## Testing Steps
1. `git checkout 6dbfbc296a693c3f4031fd611f94d1b3cb8aeae1`
2. `npm i && npm run dev` 
3. Create a new account
4. `git checkout main`
5. `npm i && npm run dev` 
6. App should load without `.split` error

## Link to issue

https://discord.com/channels/478735028319158273/560980601155616802/1060640799039172770

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

