### PR TITLE
Avivash/add playwright infrastructure

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
       preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@master
+        uses: patrickedqvist/wait-for-vercel-preview@main
         id: waitForVercelPreviewDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
       - run: npm ci
       - run: npx playwright install --with-deps
       - name: Run tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,36 @@
+name: Playwright Tests
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test_setup:
+    name: Test setup
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
+    steps:
+      - name: Wait for Vercel preview deployment to be ready
+        uses: patrickedqvist/wait-for-vercel-preview@master
+        id: waitForVercelPreviewDeployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 300
+  test_e2e:
+    needs: test_setup
+    name: Playwright tests
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare testing env
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - name: Run tests
+        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ needs.test_setup.outputs.preview_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 
 # macOS
 .DS_Store
+
+# playwright
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 
 # macOS
 .DS_Store
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "webnative": "^0.35.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.29.2",
         "@sveltejs/adapter-static": "1.0.0-next.43",
         "@sveltejs/kit": "1.0.0-next.489",
         "@tailwindcss/typography": "^0.5.2",
@@ -428,6 +429,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.29.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -4170,6 +4187,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/plur": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
@@ -6092,6 +6121,16 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.29.2"
       }
     },
     "@polka/url": {
@@ -8709,6 +8748,12 @@
         "find-up": "^6.0.0",
         "load-json-file": "^7.0.0"
       }
+    },
+    "playwright-core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+      "dev": true
     },
     "plur": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "ava src/**/*.test.ts",
+    "test:e2e": "playwright test",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint './src/**/*.{js,ts,svelte}'",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write --plugin-search-dir=. ."
   },
   "devDependencies": {
+    "@playwright/test": "^1.29.2",
     "@sveltejs/adapter-static": "1.0.0-next.43",
     "@sveltejs/kit": "1.0.0-next.489",
     "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview",
     "test": "ava src/**/*.test.ts",
     "test:e2e": "playwright test",
+    "report:e2e": "playwright show-report",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint './src/**/*.{js,ts,svelte}'",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,35 +63,29 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Safari']
       }
-    }
+    },
 
     /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: {
-    //     ...devices['Pixel 5'],
-    //   },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: {
-    //     ...devices['iPhone 12'],
-    //   },
-    // },
+    {
+      name: 'Mobile Chrome',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+    {
+      name: 'Mobile Safari',
+      use: {
+        ...devices['iPhone 12'],
+      },
+    },
 
     /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: {
-    //     channel: 'msedge',
-    //   },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: {
-    //     channel: 'chrome',
-    //   },
-    // },
+    {
+      name: 'Google Chrome',
+      use: {
+        channel: 'chrome',
+      },
+    },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,107 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://127.0.0.1:5173',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry'
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox']
+      }
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari']
+      }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    port: 5173
+  }
+}
+
+export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -78,14 +78,6 @@ const config: PlaywrightTestConfig = {
         ...devices['iPhone 12'],
       },
     },
-
-    /* Test against branded browsers. */
-    {
-      name: 'Google Chrome',
-      use: {
-        channel: 'chrome',
-      },
-    },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('http://127.0.0.1:5173');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Webnative SDK Demo/)
+});
+
+test('get register link', async ({ page }) => {
+  await page.goto('http://127.0.0.1:5173');
+
+  // Click the register link.
+  await page.getByRole('link', { name: 'Connect this device' }).click();
+
+  // Expects the URL to contain register.
+  await expect(page).toHaveURL(/.*register/);
+});

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,18 +1,13 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
 
-test('has title', async ({ page }) => {
-  await page.goto('/');
+import { appName } from '../src/lib/app-info'
 
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Webnative SDK Demo/)
-});
-
-test('get register link', async ({ page }) => {
-  await page.goto('/');
+test('find and click register link', async ({ page }) => {
+  await page.goto('/')
 
   // Click the register link.
-  await page.getByRole('link', { name: 'Connect this device' }).click();
+  await page.getByRole('link', { name: 'Connect this device' }).click()
 
   // Expects the URL to contain register.
-  await expect(page).toHaveURL(/.*register/);
-});
+  await expect(page).toHaveURL(/.*register/)
+})

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 test('has title', async ({ page }) => {
-  await page.goto('http://127.0.0.1:5173');
+  await page.goto('/');
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Webnative SDK Demo/)
 });
 
 test('get register link', async ({ page }) => {
-  await page.goto('http://127.0.0.1:5173');
+  await page.goto('/');
 
   // Click the register link.
   await page.getByRole('link', { name: 'Connect this device' }).click();

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test'
 
-import { appName } from '../src/lib/app-info'
-
 test('find and click register link', async ({ page }) => {
   await page.goto('/')
 


### PR DESCRIPTION
# Description

Adding a basic [Playwright](https://playwright.dev/) test to WAT. As of now, it will simply check if the homepage is loaded and check if clicking the `register` button takes you to the `register` route. We can add more tests to the test suite over time.

These tests can be run for the local dev environment by running `npm run test:e2e` and will automatically be run as part of the CI flow against the PR's vercel domain to ensure the production build works as expected.

## Link to issue

https://github.com/webnative-examples/webnative-app-template/issues/111

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots/Screencaps

https://www.loom.com/share/f9bbbde7255b442bb2910ef9bdcb5354
