### PR TITLE
Feat: use program.recoverFileSystem instead of doing it manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "clipboard-copy": "^4.0.1",
         "qrcode-svg": "^1.1.0",
         "uint8arrays": "^4.0.2",
-        "webnative": "fission-codes/webnative#avivash/fs-recovery"
+        "webnative": "^0.36.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.29.2",
@@ -6322,9 +6322,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.35.2",
-      "resolved": "git+ssh://git@github.com/fission-codes/webnative.git#7bd43f8688da4ee4b9902e1efff5f451fbd9fcc4",
-      "license": "Apache-2.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.0.tgz",
+      "integrity": "sha512-gU+a3EvyqcG8yifZW+5ioQcuq/fRX4K3PXDqr2cSYnQhWc3C6DW5r/g+N5uFFL16huCJbn1lg0iSPJAu9El5Ww==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -10971,8 +10971,9 @@
       "requires": {}
     },
     "webnative": {
-      "version": "git+ssh://git@github.com/fission-codes/webnative.git#7bd43f8688da4ee4b9902e1efff5f451fbd9fcc4",
-      "from": "webnative@fission-codes/webnative#avivash/fs-recovery",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.0.tgz",
+      "integrity": "sha512-gU+a3EvyqcG8yifZW+5ioQcuq/fRX4K3PXDqr2cSYnQhWc3C6DW5r/g+N5uFFL16huCJbn1lg0iSPJAu9El5Ww==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "clipboard-copy": "^4.0.1",
         "qrcode-svg": "^1.1.0",
         "uint8arrays": "^4.0.2",
-        "webnative": "^0.35.1"
+        "webnative": "fission-codes/webnative#avivash/fs-recovery"
       },
       "devDependencies": {
         "@playwright/test": "^1.29.2",
@@ -6323,8 +6323,8 @@
     },
     "node_modules/webnative": {
       "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "resolved": "git+ssh://git@github.com/fission-codes/webnative.git#7bd43f8688da4ee4b9902e1efff5f451fbd9fcc4",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -10971,9 +10971,8 @@
       "requires": {}
     },
     "webnative": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "version": "git+ssh://git@github.com/fission-codes/webnative.git#7bd43f8688da4ee4b9902e1efff5f451fbd9fcc4",
+      "from": "webnative@fission-codes/webnative#avivash/fs-recovery",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "clipboard-copy": "^4.0.1",
     "qrcode-svg": "^1.1.0",
     "uint8arrays": "^4.0.2",
-    "webnative": "fission-codes/webnative#avivash/fs-recovery"
+    "webnative": "^0.36.0"
   },
   "engines": {
     "node": ">=16.14"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "clipboard-copy": "^4.0.1",
     "qrcode-svg": "^1.1.0",
     "uint8arrays": "^4.0.2",
-    "webnative": "^0.35.1"
+    "webnative": "fission-codes/webnative#avivash/fs-recovery"
   },
   "engines": {
     "node": ">=16.14"

--- a/src/components/auth/recover/HasRecoveryKit.svelte
+++ b/src/components/auth/recover/HasRecoveryKit.svelte
@@ -58,7 +58,7 @@
         storage.setItem(USERNAME_STORAGE_KEY, newUsername)
 
         // Recover user's file system
-        const { success } = await $sessionStore.program.recoverFileSystem({
+        const { success } = await $sessionStore.program.fileSystem.recover({
           newUsername: hashedNewUsername,
           oldUsername: hashedOldUsername,
           readKey


### PR DESCRIPTION
# Description

Moving the FileSystem recovery functionality into `webnative`. Devs can now call the `fileSystem.recover` method directly from the `program`. It is important to note the `newUsername` and `oldUsername` that are passed in are the hashed versions, as `webnative` doesn't yet have a notion of the unhashed versions. (That will be completed in https://github.com/fission-codes/webnative/issues/385)

```ts
const { success } = await $sessionStore.program.fileSystem.recover({
  newUsername,
  oldUsername,
  readKey
})
```

**Note: I'll add this same functionality to WAT-react once these PRs have been merged**

## Link to issue

https://github.com/fission-codes/webnative/issues/427

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Screenshots/Screencaps

https://www.loom.com/share/b2ecfe8fa8a04f7e96dab76d8dc749a6

## Sibling PR

https://github.com/fission-codes/webnative/pull/461
