### PR TITLE
Improve gallery dirs and DOM types

### DIFF
--- a/fission.yaml.bak
+++ b/fission.yaml.bak
@@ -1,0 +1,3 @@
+ignore: []
+url: webnative-template.fission.app
+build: ./build

--- a/fission.yaml.bak
+++ b/fission.yaml.bak
@@ -1,3 +1,0 @@
-ignore: []
-url: webnative-template.fission.app
-build: ./build

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "clipboard-copy": "^4.0.1",
         "qrcode-svg": "^1.1.0",
         "uint8arrays": "^4.0.2",
-        "webnative": "^0.35.1"
+        "webnative": "^0.36.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.29.2",
@@ -6322,9 +6322,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.0.tgz",
+      "integrity": "sha512-gU+a3EvyqcG8yifZW+5ioQcuq/fRX4K3PXDqr2cSYnQhWc3C6DW5r/g+N5uFFL16huCJbn1lg0iSPJAu9El5Ww==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -10971,9 +10971,9 @@
       "requires": {}
     },
     "webnative": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.0.tgz",
+      "integrity": "sha512-gU+a3EvyqcG8yifZW+5ioQcuq/fRX4K3PXDqr2cSYnQhWc3C6DW5r/g+N5uFFL16huCJbn1lg0iSPJAu9El5Ww==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "clipboard-copy": "^4.0.1",
     "qrcode-svg": "^1.1.0",
     "uint8arrays": "^4.0.2",
-    "webnative": "^0.35.1"
+    "webnative": "^0.36.0"
   },
   "engines": {
     "node": ">=16.14"

--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -1,5 +1,4 @@
 import * as uint8arrays from 'uint8arrays'
-import * as webnative from 'webnative'
 import { sha256 } from 'webnative/components/crypto/implementation/browser'
 import { publicKeyToDid } from 'webnative/did/transformers'
 import type { Crypto } from 'webnative'
@@ -83,7 +82,7 @@ export const register = async (hashedUsername: string): Promise<boolean> => {
     username: {
       full: fullUsername,
       hashed: hashedUsername,
-      trimmed: fullUsername.split('#')[0]
+      trimmed: fullUsername.split('#')[ 0 ]
     },
     session
   }))
@@ -97,9 +96,9 @@ export const register = async (hashedUsername: string): Promise<boolean> => {
  * @param fs FileSystem
  */
 const initializeFilesystem = async (fs: FileSystem): Promise<void> => {
-  await fs.mkdir(webnative.path.directory(...GALLERY_DIRS[ AREAS.PUBLIC ]))
-  await fs.mkdir(webnative.path.directory(...GALLERY_DIRS[ AREAS.PRIVATE ]))
-  await fs.mkdir(webnative.path.directory(...ACCOUNT_SETTINGS_DIR))
+  await fs.mkdir(GALLERY_DIRS[ AREAS.PUBLIC ])
+  await fs.mkdir(GALLERY_DIRS[ AREAS.PRIVATE ])
+  await fs.mkdir(ACCOUNT_SETTINGS_DIR)
 }
 
 export const loadAccount = async (hashedUsername: string, fullUsername: string): Promise<void> => {
@@ -117,7 +116,7 @@ export const loadAccount = async (hashedUsername: string, fullUsername: string):
     username: {
       full: fullUsername,
       hashed: hashedUsername,
-      trimmed: fullUsername.split('#')[0],
+      trimmed: fullUsername.split('#')[ 0 ],
     },
     session,
     backupCreated: backupStatus.created

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -29,7 +29,7 @@ type Link = {
   size: number
 }
 
-export const GALLERY_DIRS = {
+export const GALLERY_DIRS: Record<string, [ wn.path.Partition, string ]>  = {
   [ AREAS.PUBLIC ]: [ 'public', 'gallery' ],
   [ AREAS.PRIVATE ]: [ 'private', 'gallery' ]
 }

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -29,9 +29,9 @@ type Link = {
   size: number
 }
 
-export const GALLERY_DIRS: Record<string, [ wn.path.Partition, string ]>  = {
-  [ AREAS.PUBLIC ]: [ 'public', 'gallery' ],
-  [ AREAS.PRIVATE ]: [ 'private', 'gallery' ]
+export const GALLERY_DIRS = {
+  [ AREAS.PUBLIC ]: wn.path.directory('public', 'gallery'),
+  [ AREAS.PRIVATE ]: wn.path.directory('private', 'gallery')
 }
 const FILE_SIZE_LIMIT = 20
 
@@ -48,7 +48,7 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
     const fs = getStore(filesystemStore)
 
     // Set path to either private or public gallery dir
-    const path = wn.path.directory(...GALLERY_DIRS[ selectedArea ])
+    const path = GALLERY_DIRS[ selectedArea ]
 
     // Get list of links for files in the gallery dir
     const links = await fs.ls(path)
@@ -56,7 +56,7 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
     let images = await Promise.all(
       Object.entries(links).map(async ([ name ]) => {
         const file = await fs.get(
-          wn.path.file(...GALLERY_DIRS[ selectedArea ], `${name}`)
+          wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(`${name}`))
         )
 
         if (!isFile(file)) return null
@@ -131,7 +131,7 @@ export const uploadImageToWNFS: (
 
     // Reject the upload if the image already exists in the directory
     const imageExists = await fs.exists(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], image.name)
+      wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(image.name))
     )
     if (imageExists) {
       throw new Error(`${image.name} image already exists`)
@@ -139,7 +139,7 @@ export const uploadImageToWNFS: (
 
     // Create a sub directory and add some content
     await fs.write(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], image.name),
+      wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(image.name)),
       await fileToUint8Array(image)
     )
 
@@ -165,12 +165,12 @@ export const deleteImageFromWNFS: (
     const fs = getStore(filesystemStore)
 
     const imageExists = await fs.exists(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], name)
+      wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(name))
     )
 
     if (imageExists) {
       // Remove images from server
-      await fs.rm(wn.path.file(...GALLERY_DIRS[ selectedArea ], name))
+      await fs.rm(wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(name)))
 
       // Announce the changes to the server
       await fs.publish()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "es2020",
-    "lib": ["es2020"],
+    "lib": ["dom", "es2020"],
     "target": "es2019",
     /**
     svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "baseUrl": ".",
     "allowJs": true,
     "checkJs": true,
+    "noEmit": true,
     "paths": {
       "$components": ["src/components"],
       "$components/*": ["src/components/*"],


### PR DESCRIPTION
# Description

This PR makes the following changes:

- [x] Refactors the directory constants eagerly create paths
- [x] Add the `dom` TypeScript lib
- [x] Sets `noEmit` to `true` in the tsconfig 

Webnative 0.36 requires stricter path types, and our existing approach to path types required explicit types that were getting a bit complex.

Also noticed along the way that we had some type errors for `window` and `FileList`. Adding the `dom` lib to the TypeScript config takes care of that.

Lastly, we had an error in `tsconfig.json` that some JavaScript files might be overwritten. The TypeScript compiler emits files alongside source, and normally we would want to set an `outDir` to avoid overwriting files. But we process files with Vite, so this isn't a concern, and we can let TypeScript it won't need to emit.

## Link to issue

Closes #120 

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

